### PR TITLE
docs: clarify that split archives are not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The databases need to comply specification maintained in the code of [linkarchiv
 Supported database types, by extension:
  - .db - SQLite table
  - .db.zip - archived SQLite table
+ 
+Note: Split archives (e.g., .zip.001, .zip.002) are not supported.
 
 # Why use Offline Web Search?
 


### PR DESCRIPTION
# docs: clarify that split archives are not supported

## Summary

This PR adds a clarification to the README that split archive files (e.g., .zip.001, .zip.002) are not supported by the OfflineWebSearch application. The issue raised whether the documentation should explicitly state that divided archives will not work, and this change addresses that by adding a note in the Databases section.

Fixes #138

## Changes

- Added a note in the Databases section stating that split archive files are not supported

## Testing

- Verified the change renders correctly in the README
- Confirmed no existing documentation contradicts this information
- Made only the minimal necessary change to address the issue

---
### AI disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
